### PR TITLE
Feature/fpc 1100 display message unkown rfid tag instead of missing entitlement

### DIFF
--- a/src/Plugin.NFC/Plugin.NFC.csproj
+++ b/src/Plugin.NFC/Plugin.NFC.csproj
@@ -15,7 +15,7 @@
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
 		<AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
 		<Version>1.0.0.0</Version>
-		<PackageVersion>0.1.19.4</PackageVersion>
+		<PackageVersion>0.1.19.5</PackageVersion>
 		<PackOnBuild>true</PackOnBuild>
 		<NeutralLanguage>en</NeutralLanguage>
 		<DefineConstants>$(DefineConstants);</DefineConstants>

--- a/src/Plugin.NFC/Plugin.NFC.csproj
+++ b/src/Plugin.NFC/Plugin.NFC.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <Project Sdk="MSBuild.Sdk.Extras/2.0.54">
   <PropertyGroup>
     <!--Work around so the conditions work below-->

--- a/src/Plugin.NFC/Plugin.NFC.csproj
+++ b/src/Plugin.NFC/Plugin.NFC.csproj
@@ -15,7 +15,7 @@
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
     <Version>1.0.0.0</Version>
-    <PackageVersion>0.1.19.5</PackageVersion>
+    <PackageVersion>0.1.19.6</PackageVersion>
     <PackOnBuild>true</PackOnBuild>
     <NeutralLanguage>en</NeutralLanguage>
     <DefineConstants>$(DefineConstants);</DefineConstants>

--- a/src/Plugin.NFC/Plugin.NFC.csproj
+++ b/src/Plugin.NFC/Plugin.NFC.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras/2.0.54">
   <PropertyGroup>
     <!--Work around so the conditions work below-->
@@ -15,7 +15,7 @@
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
     <Version>1.0.0.0</Version>
-    <PackageVersion>0.1.19.4</PackageVersion>
+    <PackageVersion>0.1.19.5</PackageVersion>
     <PackOnBuild>true</PackOnBuild>
     <NeutralLanguage>en</NeutralLanguage>
     <DefineConstants>$(DefineConstants);</DefineConstants>

--- a/src/Plugin.NFC/Shared/NfcConfiguration.shared.cs
+++ b/src/Plugin.NFC/Shared/NfcConfiguration.shared.cs
@@ -48,6 +48,7 @@
 		string _nfcSuccessRead = "Read Operation Successful";
 		string _nfcSuccessWrite = "Write Operation Successful";
 		string _nfcSuccessClear = "Clear Operation Successful";
+		string _nfcMissingEntitlement = "Missing required entitlement";
 
 		/// <summary>
 		/// Writing feature not supported
@@ -230,5 +231,19 @@
 					_nfcSuccessClear = value;
 			}
 		}
+		
+		/// <summary>
+		/// [iOS] Error message for a missing required entitlement.
+		/// </summary>
+		public string NFCMissingEntitlement
+		{
+			get => _nfcMissingEntitlement;
+			set
+			{
+				if (!string.IsNullOrWhiteSpace(value))
+					_nfcMissingEntitlement = value;
+			}
+		}
+		
 	}
 }

--- a/src/Plugin.NFC/iOS/NFC.iOS.cs
+++ b/src/Plugin.NFC/iOS/NFC.iOS.cs
@@ -207,6 +207,8 @@ namespace Plugin.NFC
 						// let the user decide if ndef support is needed
 						OnMessageReceived?.Invoke(nTag);
 
+						session.AlertMessage = Configuration.Messages.NFCSuccessRead;
+
 						Invalidate(session);
 
 						return;

--- a/src/Plugin.NFC/iOS/NFC.iOS.cs
+++ b/src/Plugin.NFC/iOS/NFC.iOS.cs
@@ -160,6 +160,8 @@ namespace Plugin.NFC
 					   new DebugInfo("Can't connect to tag!", error.DebugDescription, _tag.Type.ToString(), tags.Length, error.Code.ToString(), ((NFCReaderError)(long)error.Code).ToString())
 					   );
 
+					// error code 2 represents missing entitlement
+					connectionError = error.Code == 2 ? Configuration.Messages.NFCMissingEntitlement : connectionError;
 					Invalidate(session, connectionError);
 					return;
 				}


### PR DESCRIPTION
- add missing entitlement message
- set success message for successful reading tags without ndef support